### PR TITLE
Add tests in the new (json) supported config format 

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,23 +12,39 @@ user_test_LDFLAGS = -no-install
 
 TESTS_SHELLSCRIPTS = \
 	parser_whitespace.sh \
+	parser_whitespace_jsoncnf.sh \
 	parser_LF.sh \
+	parser_LF_jsoncnf.sh \
 	field_hexnumber.sh \
 	field_hexnumber_jsoncnf.sh \
 	field_hexnumber_range.sh \
+	field_hexnumber_range_jsoncnf.sh \
 	field_mac48.sh \
+	field_mac48_jsoncnf.sh \
 	field_name_value.sh \
+	field_name_value_jsoncnf.sh \
 	field_kernel_timestamp.sh \
+	field_kernel_timestamp_jsoncnf.sh \
 	field_whitespace.sh \
+	field_whitespace_jsoncnf.sh \
 	field_rest.sh \
+	field_rest_jsoncnf.sh \
 	field_json.sh \
+	field_json_jsoncnf.sh \
 	field_cee-syslog.sh \
+	field_cee-syslog_jsoncnf.sh \
 	field_ipv6.sh \
+	field_ipv6_jsoncnf.sh \
 	field_v2-iptables.sh \
+	field_v2-iptables_jsoncnf.sh \
 	field_cef.sh \
+	field_cef_jsoncnf.sh \
 	field_checkpoint-lea.sh \
+	field_checkpoint-lea_jsoncnf.sh \
 	field_duration.sh \
-        field_float.sh
+	field_duration_jsoncnf.sh \
+        field_float.sh \ 
+        field_float_jsoncnf.sh 
 # removed because test is not valid.
 # more info: https://github.com/rsyslog/liblognorm/issues/98
 # note that probably the other currently disable *_invalid_*.sh

--- a/tests/field_cee-syslog_jsoncnf.sh
+++ b/tests/field_cee-syslog_jsoncnf.sh
@@ -1,0 +1,28 @@
+# added 2015-03-01 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "JSON field"
+add_rule 'rule=:%{"name":"field", "type":"cee-syslog"}%'
+
+execute '@cee:{"f1": "1", "f2": 2}'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+execute '@cee:{"f1": "1", "f2": 2} ' # note the trailing space
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+execute '@cee: {"f1": "1", "f2": 2}'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+execute '@cee:     {"f1": "1", "f2": 2}'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+#
+# Things that MUST NOT work
+#
+execute '@cee: {"f1": "1", "f2": 2} data'
+assert_output_json_eq '{ "originalmsg": "@cee: {\"f1\": \"1\", \"f2\": 2} data", "unparsed-data": "@cee: {\"f1\": \"1\", \"f2\": 2} data" }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_cef_jsoncnf.sh
+++ b/tests/field_cef_jsoncnf.sh
@@ -1,0 +1,57 @@
+# added 2015-05-05 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "CEF parser"
+add_rule 'rule=:%{"name":"f", "type":"cef"}%'
+
+# fabricated tests to test specific functionality
+execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| aa=field1 bb=this is a value cc=field 3'
+assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { "aa": "field1", "bb": "this is a value", "cc": "field 3" } } }'
+
+execute 'CEF:0|Vendor|Product\|1\|\\|Version|Signature ID|some name|Severity| aa=field1 bb=this is a name\=value cc=field 3'
+assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product|1|\\", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { "aa": "field1", "bb": "this is a name=value", "cc": "field 3" } } }'
+
+execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| aa=field1 bb=this is a \= value cc=field 3'
+assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { "aa": "field1", "bb": "this is a = value", "cc": "field 3" } } }'
+
+execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity|'
+assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { } } }'
+
+execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| name=value'
+assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { "name": "value" } } }'
+
+execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| name=val\nue' # embedded LF
+assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { "name": "val\nue" } } }'
+
+execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| n,me=value' #invalid punctuation in extension
+assert_output_json_eq '{ "originalmsg": "CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| n,me=value", "unparsed-data": "CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| n,me=value" }'
+
+execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| name=v\alue' #invalid escape in extension
+assert_output_json_eq '{ "originalmsg": "CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| name=v\\alue", "unparsed-data": "CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| name=v\\alue" }'
+
+execute 'CEF:0|V\endor|Product|Version|Signature ID|some name|Severity| name=value' #invalid escape in header
+assert_output_json_eq '{ "originalmsg": "CEF:0|V\\endor|Product|Version|Signature ID|some name|Severity| name=value", "unparsed-data": "CEF:0|V\\endor|Product|Version|Signature ID|some name|Severity| name=value" }'
+
+execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| ' # single trailing space - valid
+assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { } } }'
+
+execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity|   ' # multiple trailing spaces - invalid
+assert_output_json_eq '{ "originalmsg": "CEF:0|Vendor|Product|Version|Signature ID|some name|Severity|   ", "unparsed-data": "CEF:0|Vendor|Product|Version|Signature ID|some name|Severity|   " }'
+
+execute 'CEF:0|Vendor'
+assert_output_json_eq '{ "originalmsg": "CEF:0|Vendor", "unparsed-data": "CEF:0|Vendor" }'
+
+execute 'CEF:1|Vendor|Product|Version|Signature ID|some name|Severity| aa=field1 bb=this is a \= value cc=field 3'
+assert_output_json_eq '{ "originalmsg": "CEF:1|Vendor|Product|Version|Signature ID|some name|Severity| aa=field1 bb=this is a \\= value cc=field 3", "unparsed-data": "CEF:1|Vendor|Product|Version|Signature ID|some name|Severity| aa=field1 bb=this is a \\= value cc=field 3" }'
+
+execute ''
+assert_output_json_eq '{ "originalmsg": "", "unparsed-data": "" }'
+
+# finally, a use case from practice
+execute 'CEF:0|ArcSight|ArcSight|10.0.0.15.0|rule:101|FOO-UNIX-Bypassing Golden Host-Direct Root Connection Attempt|High| eventId=24934046519 type=2 mrt=8888882444085 sessionId=0 generatorID=34rSQWFOOOCAVlswcKFkbA\=\= categorySignificance=/Normal categoryBehavior=/Execute/Query categoryDeviceGroup=/Application categoryOutcome=/Success categoryObject=/Host/Application modelConfidence=0 severity=0 relevance=10 assetCriticality=0 priority=2 art=1427882454263 cat=/Detection/FOO/UNIX/Direct Root Connection Attempt deviceSeverity=Warning rt=1427881661000 shost=server.foo.bar src=10.0.0.1 sourceZoneID=MRL4p30sFOOO8panjcQnFbw\=\= sourceZoneURI=/All Zones/FOO Solutions/Server Subnet/UK/PAR-WDC-12-CELL5-PROD S2U 1 10.0.0.1-10.0.0.1 sourceGeoCountryCode=GB sourceGeoLocationInfo=London slong=-0.90843 slat=51.9039 dhost=server.foo.bar dst=10.0.0.1 destinationZoneID=McFOOO0sBABCUHR83pKJmQA\=\= destinationZoneURI=/All Zones/FOO Solutions/Prod/AMERICAS/FOO 10.0.0.1-10.0.0.1 duser=johndoe destinationGeoCountryCode=US destinationGeoLocationInfo=Jersey City dlong=-90.0435 dlat=30.732 fname=FOO-UNIX-Bypassing Golden Host-Direct Root Connection Attempt filePath=/All Rules/Real-time Rules/ACBP-ACCESS CONTROL and AUTHORIZATION/FOO/Unix Server/FOO-UNIX-Bypassing Golden Host-Direct Root Connection Attempt fileType=Rule ruleThreadId=NQVtdFOOABDrKsmLWpyq8g\=\= cs2=<Resource URI\=""/All Rules/Real-time Rules/FOO-ACCESS CONTROL and AUTHORIZATION/FOO/Unix Server/FOO-UNIX-Bypassing Golden Host-Direct Root Connection Attempt"" ID\=""5lzFOO--RTSN-TESTQ\=\=""/> flexString2=DC0001-988 locality=1 cs2Label=Configuration Resource ahost=foo.bar agt=10.0.0.1 av=10.0.0.12 atz=Europe/Berlin aid=34rSQWFOOOBCAVlswcKFkbA\=\= at=superagent_ng dvchost=server.foo.bar dvc=10.0.0.1 deviceZoneID=Mbb8pFOOODol1dBKdURJA\=\= deviceZoneURI=/All Zones/FOO Solutions/Prod/GERMANY/FOO US2 Class6 A 508 10.0.0.1-10.0.0.1 dtz=Europe/Berlin deviceFacility=Rules Engine eventAnnotationStageUpdateTime=1427882444192 eventAnnotationModificationTime=1427882444192 eventAnnotationAuditTrail=1,1427453188050,root,Queued,,,,\n eventAnnotationVersion=1 eventAnnotationFlags=0 eventAnnotationEndTime=1427881661000 eventAnnotationManagerReceiptTime=1427882444085 _cefVer=0.1 ad.arcSightEventPath=3VcygrkkBABCAYFOOLlU13A\=\= baseEventIds=24934003731"'
+assert_output_json_eq '{ "f": { "DeviceVendor": "ArcSight", "DeviceProduct": "ArcSight", "DeviceVersion": "10.0.0.15.0", "SignatureID": "rule:101", "Name": "FOO-UNIX-Bypassing Golden Host-Direct Root Connection Attempt", "Severity": "High", "Extensions": { "eventId": "24934046519", "type": "2", "mrt": "8888882444085", "sessionId": "0", "generatorID": "34rSQWFOOOCAVlswcKFkbA==", "categorySignificance": "\/Normal", "categoryBehavior": "\/Execute\/Query", "categoryDeviceGroup": "\/Application", "categoryOutcome": "\/Success", "categoryObject": "\/Host\/Application", "modelConfidence": "0", "severity": "0", "relevance": "10", "assetCriticality": "0", "priority": "2", "art": "1427882454263", "cat": "\/Detection\/FOO\/UNIX\/Direct Root Connection Attempt", "deviceSeverity": "Warning", "rt": "1427881661000", "shost": "server.foo.bar", "src": "10.0.0.1", "sourceZoneID": "MRL4p30sFOOO8panjcQnFbw==", "sourceZoneURI": "\/All Zones\/FOO Solutions\/Server Subnet\/UK\/PAR-WDC-12-CELL5-PROD S2U 1 10.0.0.1-10.0.0.1", "sourceGeoCountryCode": "GB", "sourceGeoLocationInfo": "London", "slong": "-0.90843", "slat": "51.9039", "dhost": "server.foo.bar", "dst": "10.0.0.1", "destinationZoneID": "McFOOO0sBABCUHR83pKJmQA==", "destinationZoneURI": "\/All Zones\/FOO Solutions\/Prod\/AMERICAS\/FOO 10.0.0.1-10.0.0.1", "duser": "johndoe", "destinationGeoCountryCode": "US", "destinationGeoLocationInfo": "Jersey City", "dlong": "-90.0435", "dlat": "30.732", "fname": "FOO-UNIX-Bypassing Golden Host-Direct Root Connection Attempt", "filePath": "\/All Rules\/Real-time Rules\/ACBP-ACCESS CONTROL and AUTHORIZATION\/FOO\/Unix Server\/FOO-UNIX-Bypassing Golden Host-Direct Root Connection Attempt", "fileType": "Rule", "ruleThreadId": "NQVtdFOOABDrKsmLWpyq8g==", "cs2": "<Resource URI=\"\"\/All Rules\/Real-time Rules\/FOO-ACCESS CONTROL and AUTHORIZATION\/FOO\/Unix Server\/FOO-UNIX-Bypassing Golden Host-Direct Root Connection Attempt\"\" ID=\"\"5lzFOO--RTSN-TESTQ==\"\"\/>", "flexString2": "DC0001-988", "locality": "1", "cs2Label": "Configuration Resource", "ahost": "foo.bar", "agt": "10.0.0.1", "av": "10.0.0.12", "atz": "Europe\/Berlin", "aid": "34rSQWFOOOBCAVlswcKFkbA==", "at": "superagent_ng", "dvchost": "server.foo.bar", "dvc": "10.0.0.1", "deviceZoneID": "Mbb8pFOOODol1dBKdURJA==", "deviceZoneURI": "\/All Zones\/FOO Solutions\/Prod\/GERMANY\/FOO US2 Class6 A 508 10.0.0.1-10.0.0.1", "dtz": "Europe\/Berlin", "deviceFacility": "Rules Engine", "eventAnnotationStageUpdateTime": "1427882444192", "eventAnnotationModificationTime": "1427882444192", "eventAnnotationAuditTrail": "1,1427453188050,root,Queued,,,,\n", "eventAnnotationVersion": "1", "eventAnnotationFlags": "0", "eventAnnotationEndTime": "1427881661000", "eventAnnotationManagerReceiptTime": "1427882444085", "_cefVer": "0.1", "ad.arcSightEventPath": "3VcygrkkBABCAYFOOLlU13A==", "baseEventIds": "24934003731\"" } } }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_checkpoint-lea_jsoncnf.sh
+++ b/tests/field_checkpoint-lea_jsoncnf.sh
@@ -1,0 +1,13 @@
+# added 2015-06-18 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "Checkpoint LEA parser"
+add_rule 'rule=:%{"name":"f", "type":"checkpoint-lea"}%'
+
+execute 'tcp_flags: RST-ACK; src: 192.168.0.1;'
+assert_output_json_eq '{ "f": { "tcp_flags": "RST-ACK", "src": "192.168.0.1" } }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_duration_jsoncnf.sh
+++ b/tests/field_duration_jsoncnf.sh
@@ -1,0 +1,29 @@
+# added 2015-03-12 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "duration syntax"
+add_rule 'rule=:duration %{"name":"field", "type":"duration"}% bytes'
+add_rule 'rule=:duration %{"name":"field", "type":"duration"}%'
+
+execute 'duration 0:00:42 bytes'
+assert_output_json_eq '{"field": "0:00:42"}'
+
+execute 'duration 0:00:42'
+assert_output_json_eq '{"field": "0:00:42"}'
+
+execute 'duration 9:00:42 bytes'
+assert_output_json_eq '{"field": "9:00:42"}'
+
+execute 'duration 00:00:42 bytes'
+assert_output_json_eq '{"field": "00:00:42"}'
+
+execute 'duration 37:59:42 bytes'
+assert_output_json_eq '{"field": "37:59:42"}'
+
+execute 'duration 37:60:42 bytes'
+assert_output_contains '"unparsed-data": "37:60:42 bytes"'
+
+
+cleanup_tmp_files
+

--- a/tests/field_float_jsoncnf.sh
+++ b/tests/field_float_jsoncnf.sh
@@ -1,0 +1,24 @@
+# added 2015-02-25 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "float field"
+add_rule 'rule=:here is a number %{"name":"num", "type":"float"}% in floating pt form'
+execute 'here is a number 15.9 in floating pt form'
+assert_output_json_eq '{"num": "15.9"}'
+
+reset_rules
+
+add_rule 'rule=:here is a negative number %{"name":"num", "type":"float"}% for you'
+execute 'here is a negative number -4.2 for you'
+assert_output_json_eq '{"num": "-4.2"}'
+
+reset_rules
+
+add_rule 'rule=:here is another real number %{"name":"real_no", "type":"float"}%.'
+execute 'here is another real number 2.71.'
+assert_output_json_eq '{"real_no": "2.71"}'
+
+
+cleanup_tmp_files
+

--- a/tests/field_hexnumber_range_jsoncnf.sh
+++ b/tests/field_hexnumber_range_jsoncnf.sh
@@ -1,0 +1,21 @@
+# added 2015-03-01 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+
+. $srcdir/exec.sh
+
+test_def $0 "hexnumber field with range checks"
+add_rule 'rule=:here is a number %{"name":"num", "type":"hexnumber", "maxval":191}% in hex form'
+execute 'here is a number 0x12 in hex form'
+assert_output_json_eq '{"num": "0x12"}'
+execute 'here is a number 0x0 in hex form'
+assert_output_json_eq '{"num": "0x0"}'
+execute 'here is a number 0xBf in hex form'
+assert_output_json_eq '{"num": "0xBf"}'
+
+#check cases where parsing failure must occur
+execute 'here is a number 0xc0 in hex form'
+assert_output_json_eq '{ "originalmsg": "here is a number 0xc0 in hex form", "unparsed-data": "0xc0 in hex form" }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_ipv6_jsoncnf.sh
+++ b/tests/field_ipv6_jsoncnf.sh
@@ -1,0 +1,56 @@
+# added 2015-06-23 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "IPv6 parser"
+add_rule 'rule=:%{"name":"f", "type":"ipv6"}%'
+
+# examples from RFC4291, sect. 2.2
+execute 'ABCD:EF01:2345:6789:ABCD:EF01:2345:6789'
+assert_output_json_eq '{ "f": "ABCD:EF01:2345:6789:ABCD:EF01:2345:6789" }'
+execute 'ABCD:EF01:2345:6789:abcd:EF01:2345:6789' # mixed hex case
+assert_output_json_eq '{ "f": "ABCD:EF01:2345:6789:abcd:EF01:2345:6789" }'
+execute '2001:DB8:0:0:8:800:200C:417A'
+assert_output_json_eq '{ "f": "2001:DB8:0:0:8:800:200C:417A" }'
+
+execute '0:0:0:0:0:0:0:1'
+assert_output_json_eq '{ "f": "0:0:0:0:0:0:0:1" }'
+
+execute '2001:DB8::8:800:200C:417A'
+assert_output_json_eq '{ "f": "2001:DB8::8:800:200C:417A" }'
+execute 'FF01::101'
+assert_output_json_eq '{ "f": "FF01::101" }'
+execute '::1'
+assert_output_json_eq '{ "f": "::1" }'
+execute '::'
+assert_output_json_eq '{ "f": "::" }'
+
+execute '0:0:0:0:0:0:13.1.68.3'
+assert_output_json_eq '{ "f": "0:0:0:0:0:0:13.1.68.3" }'
+execute '::13.1.68.3'
+assert_output_json_eq '{ "f": "::13.1.68.3" }'
+execute '::FFFF:129.144.52.38'
+assert_output_json_eq '{ "f": "::FFFF:129.144.52.38" }'
+
+# invalid samples
+execute '2001:DB8::8::800:200C:417A' # two :: sequences
+assert_output_json_eq '{ "originalmsg": "2001:DB8::8::800:200C:417A", "unparsed-data": "2001:DB8::8::800:200C:417A" }'
+
+execute 'ABCD:EF01:2345:6789:ABCD:EF01:2345::6789' # :: with too many blocks
+assert_output_json_eq '{ "originalmsg": "ABCD:EF01:2345:6789:ABCD:EF01:2345::6789", "unparsed-data": "ABCD:EF01:2345:6789:ABCD:EF01:2345::6789" }'
+
+execute 'ABCD:EF01:2345:6789:ABCD:EF01:2345:1:6798' # too many blocks (9)
+assert_output_json_eq '{"originalmsg": "ABCD:EF01:2345:6789:ABCD:EF01:2345:1:6798", "unparsed-data": "ABCD:EF01:2345:6789:ABCD:EF01:2345:1:6798" }'
+
+execute ':0:0:0:0:0:0:1' # missing first digit
+assert_output_json_eq '{ "originalmsg": ":0:0:0:0:0:0:1", "unparsed-data": ":0:0:0:0:0:0:1" }'
+
+execute '0:0:0:0:0:0:0:' # missing last digit
+assert_output_json_eq '{ "originalmsg": "0:0:0:0:0:0:0:", "unparsed-data": "0:0:0:0:0:0:0:" }'
+
+execute '13.1.68.3' # pure IPv4 address
+assert_output_json_eq '{ "originalmsg": "13.1.68.3", "unparsed-data": "13.1.68.3" }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_json_jsoncnf.sh
+++ b/tests/field_json_jsoncnf.sh
@@ -1,0 +1,63 @@
+# added 2015-03-01 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "JSON field"
+add_rule 'rule=:%{"name":"field", "type":"json"}%'
+
+execute '{"f1": "1", "f2": 2}'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+# let's see if something more complicated still works, so ADD some
+# more rules
+add_rule 'rule=:begin %field:json%'
+add_rule 'rule=:begin %field:json%end'
+add_rule 'rule=:%field:json%end'
+
+execute '{"f1": "1", "f2": 2}'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+#check if trailinge whitspace is ignored
+execute '{"f1": "1", "f2": 2}      '
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+execute 'begin {"f1": "1", "f2": 2}'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+execute 'begin {"f1": "1", "f2": 2}end'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+# note: the parser takes all whitespace after the JSON
+# to be part of it!
+execute 'begin {"f1": "1", "f2": 2} end'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+execute 'begin {"f1": "1", "f2": 2} 	     end'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+execute '{"f1": "1", "f2": 2}end'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+#check cases where parsing failure must occur
+execute '{"f1": "1", f2: 2}'
+assert_output_json_eq '{ "originalmsg": "{\"f1\": \"1\", f2: 2}", "unparsed-data": "{\"f1\": \"1\", f2: 2}" }'
+
+#some more complex cases
+add_rule 'rule=:%field1:json%-%field2:json%'
+
+execute '{"f1": "1"}-{"f2": 2}'
+assert_output_json_eq '{ "field2": { "f2": 2 }, "field1": { "f1": "1" } }'
+
+# re-check previsous def still works
+execute '{"f1": "1", "f2": 2}'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+# now check some strange cases
+reset_rules
+add_rule 'rule=:%field:json%'
+
+# this check is because of bug in json-c:
+# https://github.com/json-c/json-c/issues/181
+execute '15:00'
+assert_output_json_eq '{ "originalmsg": "15:00", "unparsed-data": "15:00" }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_kernel_timestamp_jsoncnf.sh
+++ b/tests/field_kernel_timestamp_jsoncnf.sh
@@ -1,0 +1,49 @@
+# added 2015-03-12 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "kernel timestamp parser"
+add_rule 'rule=:begin %{"name":"timestamp", "type":"kernel-timestamp"}% end'
+execute 'begin [12345.123456] end'
+assert_output_json_eq '{ "timestamp": "[12345.123456]"}'
+
+reset_rules
+
+add_rule 'rule=:begin %{"name":"timestamp", "type":"kernel-timestamp"}%'
+execute 'begin [12345.123456]'
+assert_output_json_eq '{ "timestamp": "[12345.123456]"}'
+
+reset_rules
+
+add_rule 'rule=:%{"name":"timestamp", "type":"kernel-timestamp"}%'
+execute '[12345.123456]'
+assert_output_json_eq '{ "timestamp": "[12345.123456]"}'
+
+execute '[154469.133028]'
+assert_output_json_eq '{ "timestamp": "[154469.133028]"}'
+
+execute '[123456789012.123456]'
+assert_output_json_eq '{ "timestamp": "[123456789012.123456]"}'
+
+#check cases where parsing failure must occur
+execute '[1234.123456]'
+assert_output_json_eq '{"originalmsg": "[1234.123456]", "unparsed-data": "[1234.123456]" }'
+
+execute '[1234567890123.123456]'
+assert_output_json_eq '{"originalmsg": "[1234567890123.123456]", "unparsed-data": "[1234567890123.123456]" }'
+
+execute '[123456789012.12345]'
+assert_output_json_eq '{ "originalmsg": "[123456789012.12345]", "unparsed-data": "[123456789012.12345]" }'
+
+execute '[123456789012.1234567]'
+assert_output_json_eq '{ "originalmsg": "[123456789012.1234567]", "unparsed-data": "[123456789012.1234567]" }'
+
+execute '(123456789012.123456]'
+assert_output_json_eq '{ "originalmsg": "(123456789012.123456]", "unparsed-data": "(123456789012.123456]" }'
+
+execute '[123456789012.123456'
+assert_output_json_eq '{ "originalmsg": "[123456789012.123456", "unparsed-data": "[123456789012.123456" }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_mac48_jsoncnf.sh
+++ b/tests/field_mac48_jsoncnf.sh
@@ -1,0 +1,24 @@
+# added 2015-05-05 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "dmac48 syntax"
+add_rule 'rule=:%{"name":"field", "type":"mac48"}%'
+
+execute 'f0:f6:1c:5f:cc:a2'
+assert_output_json_eq '{"field": "f0:f6:1c:5f:cc:a2"}'
+
+execute 'f0-f6-1c-5f-cc-a2'
+assert_output_json_eq '{"field": "f0-f6-1c-5f-cc-a2"}'
+
+# things that need to NOT match
+
+execute 'f0-f6:1c:5f:cc-a2'
+assert_output_json_eq '{ "originalmsg": "f0-f6:1c:5f:cc-a2", "unparsed-data": "f0-f6:1c:5f:cc-a2" }'
+
+execute 'f0:f6:1c:xf:cc:a2'
+assert_output_json_eq '{ "originalmsg": "f0:f6:1c:xf:cc:a2", "unparsed-data": "f0:f6:1c:xf:cc:a2" }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_name_value_jsoncnf.sh
+++ b/tests/field_name_value_jsoncnf.sh
@@ -1,0 +1,32 @@
+# added 2015-04-25 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "name/value parser"
+add_rule 'rule=:%{"name":"f", "type":"name-value-list"}%'
+
+execute 'name=value'
+assert_output_json_eq '{ "f": { "name": "value" } }'
+
+execute 'name1=value1 name2=value2 name3=value3'
+assert_output_json_eq '{ "f": { "name1": "value1", "name2": "value2", "name3": "value3" } }'
+
+execute 'name1=value1 name2=value2 name3=value3 '
+assert_output_json_eq '{ "f": { "name1": "value1", "name2": "value2", "name3": "value3" } }'
+
+execute 'name1= name2=value2 name3=value3 '
+assert_output_json_eq '{ "f": { "name1": "", "name2": "value2", "name3": "value3" } }'
+
+execute 'origin=core.action processed=67 failed=0 suspended=0 suspended.duration=0 resumed=0 '
+assert_output_json_eq '{ "f": { "origin": "core.action", "processed": "67", "failed": "0", "suspended": "0", "suspended.duration": "0", "resumed": "0" } }'
+
+# check for required non-matches
+execute 'name'
+assert_output_json_eq ' {"originalmsg": "name", "unparsed-data": "name" }'
+
+execute 'noname1 name2=value2 name3=value3 '
+assert_output_json_eq '{ "originalmsg": "noname1 name2=value2 name3=value3 ", "unparsed-data": "noname1 name2=value2 name3=value3 " }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_rest_jsoncnf.sh
+++ b/tests/field_rest_jsoncnf.sh
@@ -1,0 +1,42 @@
+# some more tests for the "rest" motif, especially to ensure that
+# "rest" will not interfere with more specific rules.
+# added 2015-04-27
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "rest matches"
+
+#tail recursion with default tail field
+add_rule 'rule=:%{"name":"iface", "type":"char-to", "extradata":":"}%:%{"name":"ip", "type":"ipv4"}%/%{"name":"port", "type":"number"}% (%{"name":"label2", "type":"char-to", "extradata":")"}%)'
+add_rule 'rule=:%{"name":"iface", "type":"char-to", "extradata":":"}%:%{"name":"ip", "type":"ipv4"}%/%{"name":"port", "type":"number"}% (%{"name":"label2", "type":"char-to", "extradata":")"}%)%{"name":"tail", "type":"rest"}%'
+add_rule 'rule=:%{"name":"iface", "type":"char-to", "extradata":":"}%:%{"name":"ip", "type":"ipv4"}%/%{"name":"port", "type":"number"}%'
+add_rule 'rule=:%{"name":"iface", "type":"char-to", "extradata":":"}%:%{"name":"ip", "type":"ipv4"}%/%{"name":"port", "type":"number"}%%{"name":"tail", "type":"rest"}%'
+
+# real-world cisco samples
+execute 'Outside:10.20.30.40/35 (40.30.20.10/35)'
+assert_output_json_eq '{ "label2": "40.30.20.10\/35", "port": "35", "ip": "10.20.30.40", "iface": "Outside" }'
+
+execute 'Outside:10.20.30.40/35 (40.30.20.10/35) with rest'
+assert_output_json_eq '{  "tail": " with rest", "label2": "40.30.20.10\/35", "port": "35", "ip": "10.20.30.40", "iface": "Outside" }'
+
+execute 'Outside:10.20.30.40/35 (40.30.20.10/35 brace missing'
+assert_output_json_eq '{ "tail": " (40.30.20.10\/35 brace missing", "port": "35", "ip": "10.20.30.40", "iface": "Outside" }'
+
+execute 'Outside:10.20.30.40/35 40.30.20.10/35'
+assert_output_json_eq '{ "tail": " 40.30.20.10\/35", "port": "35", "ip": "10.20.30.40", "iface": "Outside" }'
+
+#
+# test expected mismatches
+#
+execute 'not at all!'
+assert_output_json_eq '{ "originalmsg": "not at all!", "unparsed-data": "not at all!" }'
+
+execute 'Outside 10.20.30.40/35 40.30.20.10/35'
+assert_output_json_eq '{ "originalmsg": "Outside 10.20.30.40\/35 40.30.20.10\/35", "unparsed-data": "Outside 10.20.30.40\/35 40.30.20.10\/35" }'
+
+execute 'Outside:10.20.30.40/aa 40.30.20.10/35'
+assert_output_json_eq '{ "originalmsg": "Outside:10.20.30.40\/aa 40.30.20.10\/35", "unparsed-data": "aa 40.30.20.10\/35" }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_v2-iptables_jsoncnf.sh
+++ b/tests/field_v2-iptables_jsoncnf.sh
@@ -1,0 +1,64 @@
+# added 2015-04-30 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "v2-iptables field"
+add_rule 'rule=:iptables output denied: %{"name":"field", "type":"v2-iptables"}%'
+
+# first, a real-world case
+execute 'iptables output denied: IN= OUT=eth0 SRC=176.9.56.141 DST=168.192.14.3 LEN=32 TOS=0x00 PREC=0x00 TTL=64 ID=39110 DF PROTO=UDP SPT=49564 DPT=2010 LEN=12'
+assert_output_json_eq '{ "field": { "IN": "", "OUT": "eth0", "SRC": "176.9.56.141", "DST": "168.192.14.3", "LEN": "12", "TOS": "0x00", "PREC": "0x00", "TTL": "64", "ID": "39110", "DF": null, "PROTO": "UDP", "SPT": "49564", "DPT": "2010" } }'
+
+# now some more "fabricated" cases for better readable test
+reset_rules
+add_rule 'rule=:iptables: %field:v2-iptables%'
+
+execute 'iptables: IN=value SECOND=test'
+assert_output_json_eq '{ "field": { "IN": "value", "SECOND": "test" }} }'
+
+execute 'iptables: IN= SECOND=test'
+assert_output_json_eq '{ "field": { "IN": ""} }'
+
+execute 'iptables: IN SECOND=test'
+assert_output_json_eq '{ "field": { "IN": null} }'
+
+execute 'iptables: IN=invalue OUT=outvalue'
+assert_output_json_eq '{ "field": { "IN": "invalue", "OUT": "outvalue" } }'
+
+execute 'iptables: IN= OUT=outvalue'
+assert_output_json_eq '{ "field": { "IN": "", "OUT": "outvalue" } }'
+
+execute 'iptables: IN OUT=outvalue'
+assert_output_json_eq '{ "field": { "IN": null, "OUT": "outvalue" } }'
+
+#
+#check cases where parsing failure must occur
+#
+echo verify failure cases
+
+# lower case is not permitted
+execute 'iptables: in=value'
+assert_output_json_eq '{ "originalmsg": "iptables: in=value", "unparsed-data": "in=value" }'
+
+execute 'iptables: in='
+assert_output_json_eq '{ "originalmsg": "iptables: in=", "unparsed-data": "in=" }'
+
+execute 'iptables: in'
+assert_output_json_eq '{ "originalmsg": "iptables: in", "unparsed-data": "in" }'
+
+execute 'iptables: IN' # single field is NOT permitted!
+assert_output_json_eq '{ "originalmsg": "iptables: IN", "unparsed-data": "IN" }'
+
+# multiple spaces between n=v pairs are not permitted
+execute 'iptables: IN=invalue  OUT=outvalue'
+assert_output_json_eq '{ "originalmsg": "iptables: IN=invalue  OUT=outvalue", "unparsed-data": "IN=invalue  OUT=outvalue" }'
+
+execute 'iptables: IN=  OUT=outvalue'
+assert_output_json_eq '{ "originalmsg": "iptables: IN=  OUT=outvalue", "unparsed-data": "IN=  OUT=outvalue" }'
+
+execute 'iptables: IN  OUT=outvalue'
+assert_output_json_eq '{ "originalmsg": "iptables: IN  OUT=outvalue", "unparsed-data": "IN  OUT=outvalue" }'
+
+
+cleanup_tmp_files
+

--- a/tests/field_whitespace_jsoncnf.sh
+++ b/tests/field_whitespace_jsoncnf.sh
@@ -1,0 +1,27 @@
+# added 2015-03-12 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+test_def $0 "whitespace parser"
+# the "word" parser unfortunatly treats everything except
+# a SP as being in the word. So a HT inside a word is
+# permitted, which does not work well with what we
+# want to test here. to solve this problem, we use op-quoted-string.
+# However, we must actually quote the samples with HT, because
+# that parser also treats HT as being part of the word. But thanks
+# to the quotes, we can force it to not do that.
+# rgerhards, 2015-04-30
+add_rule 'rule=:%{"name":"a", "type":"op-quoted-string"}%%{"name":"-", "type":"whitespace"}%%{"name":"b", "type":"op-quoted-string"}%'
+
+execute 'word1  word2' # multiple spaces
+assert_output_json_eq '{ "b": "word2", "a": "word1" }'
+execute 'word1 word2' # single space
+assert_output_json_eq '{ "b": "word2", "a": "word1" }'
+execute '"word1"	"word2"' # tab (US-ASCII HT)
+assert_output_json_eq '{ "b": "word2", "a": "word1" }'
+execute '"word1"	   	"word2"' # mix of tab and spaces
+assert_output_json_eq '{ "b": "word2", "a": "word1" }'
+
+
+cleanup_tmp_files
+

--- a/tests/parser_LF_jsoncnf.sh
+++ b/tests/parser_LF_jsoncnf.sh
@@ -1,0 +1,18 @@
+# added 2015-07-15 by Rainer Gerhards
+# This checks if whitespace inside parser definitions is properly treated
+# This file is part of the liblognorm project, released under ASL 2.0
+
+. $srcdir/exec.sh
+test_def $0 "LF in parser definition"
+
+add_rule 'rule=:here is a number %{
+                "name":"num", "type":"hexnumber"
+                }% in hex form'
+execute 'here is a number 0x1234 in hex form'
+assert_output_json_eq '{"num": "0x1234"}'
+
+#check cases where parsing failure must occur
+execute 'here is a number 0x1234in hex form'
+assert_output_json_eq '{ "originalmsg": "here is a number 0x1234in hex form", "unparsed-data": "0x1234in hex form" }'
+
+cleanup_tmp_files

--- a/tests/parser_whitespace_jsoncnf.sh
+++ b/tests/parser_whitespace_jsoncnf.sh
@@ -1,0 +1,16 @@
+# added 2015-07-15 by Rainer Gerhards
+# This checks if whitespace inside parser definitions is properly treated
+# This file is part of the liblognorm project, released under ASL 2.0
+
+. $srcdir/exec.sh
+test_def $0 "whitespace in parser definition"
+
+add_rule 'rule=:here is a number %   {"name":"num", "type":"hexnumber"}   % in hex form'
+execute 'here is a number 0x1234 in hex form'
+assert_output_json_eq '{"num": "0x1234"}'
+
+#check cases where parsing failure must occur
+execute 'here is a number 0x1234in hex form'
+assert_output_json_eq '{ "originalmsg": "here is a number 0x1234in hex form", "unparsed-data": "0x1234in hex form" }'
+
+cleanup_tmp_files


### PR DESCRIPTION
I used the existing tests as a template and convert them into the new supported config format.
